### PR TITLE
Inclusion of Buffer Round

### DIFF
--- a/draw-client/src/Components/GameWindow/DrawingCanvas/DrawingCanvas.js
+++ b/draw-client/src/Components/GameWindow/DrawingCanvas/DrawingCanvas.js
@@ -6,10 +6,8 @@ const drawingCanvas = (props) => {
     if (props.game.teams) {   
         if (props.game.state === 'active') {
             wordLabel = <h3>Draw: {props.game.word}</h3>;
-        } else if (props.game.state === 'buffer' && props.game.prevWord !== "") {
-            wordLabel = <h3>Last Round: {props.game.prevWord}</h3>;
         } else {
-            wordLabel = <h3>You are the Drawer!</h3>;
+            wordLabel = null;
         }
 
         const canvas = document.querySelector('#drawing-canvas canvas');
@@ -31,8 +29,10 @@ const drawingCanvas = (props) => {
                         x: m.x,
                         y: m.y
                     });
-                    drawPoints(ctx, points);
-                    props.draw(props.team,points);
+                    if (props.game.state === 'active') {
+                        drawPoints(ctx, points);
+                        props.draw(props.team,points);
+                    }
                 }
             };
 
@@ -53,28 +53,26 @@ const drawingCanvas = (props) => {
             };
 
             const drawPoints = (ctx, points) => {
-                if (props.game.state === 'active') {
-                    // draw a basic circle instead
-                    if (points.length < 6) {
-                        let b = points[0];
-                        ctx.beginPath();
-                        ctx.arc(b.x, b.y, ctx.lineWidth / 2, 0, Math.PI * 2, !0);
-                        ctx.closePath();
-                        ctx.fill();
-                        return
-                    }
+                // draw a basic circle instead
+                if (points.length < 6) {
+                    let b = points[0];
                     ctx.beginPath();
-                    ctx.moveTo(points[0].x, points[0].y);
-                    // draw a bunch of quadratics, using the average of two points as the control point
-                    let i = 1;
-                    for (i = 1; i < points.length - 2; i++) {
-                        let c = (points[i].x + points[i + 1].x) / 2,
-                            d = (points[i].y + points[i + 1].y) / 2;
-                        ctx.quadraticCurveTo(points[i].x, points[i].y, c, d)
-                    }
-                    ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
-                    ctx.stroke();
+                    ctx.arc(b.x, b.y, ctx.lineWidth / 2, 0, Math.PI * 2, !0);
+                    ctx.closePath();
+                    ctx.fill();
+                    return
                 }
+                ctx.beginPath();
+                ctx.moveTo(points[0].x, points[0].y);
+                // draw a bunch of quadratics, using the average of two points as the control point
+                let i = 1;
+                for (i = 1; i < points.length - 2; i++) {
+                    let c = (points[i].x + points[i + 1].x) / 2,
+                        d = (points[i].y + points[i + 1].y) / 2;
+                    ctx.quadraticCurveTo(points[i].x, points[i].y, c, d)
+                }
+                ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
+                ctx.stroke();
             }
 
             const getMouse = (e, canvas) => {

--- a/draw-client/src/Components/GameWindow/GameWindow.js
+++ b/draw-client/src/Components/GameWindow/GameWindow.js
@@ -10,6 +10,7 @@ const gameWindow = (props) => {
   
     let canvas = null;
     let prevWordLabel = null;
+    let pauseBtn = null;
 
     if (props.game.teams) {
 
@@ -22,10 +23,18 @@ const gameWindow = (props) => {
             }
         }
         
-        if (props.game.state === "buffer" && props.game.prevWord !== "") {
+        if (props.game.state !== "active" && props.game.prevWord !== "") {
             prevWordLabel = <h3 className="text-center">Last Round: {props.game.prevWord}</h3>;
         } else {
             prevWordLabel = null;
+        }
+
+        if (props.game.state !== 'active') {
+        pauseBtn =  <PauseButton 
+                        game={props.game}
+                        pauseClicked={props.pauseClicked}
+                        resumeClicked={props.resumeClicked}
+                    />
         }
     }
 
@@ -41,11 +50,7 @@ const gameWindow = (props) => {
                 <div className="col-sm-4"></div>
             </div>            
             <div className="row mt-5">
-                <PauseButton 
-                    game={props.game}
-                    pauseClicked={props.pauseClicked}
-                    resumeClicked={props.resumeClicked}
-                />
+                {pauseBtn}
             </div>
             <div className="row mt-5 container ">
                 <div className="col-sm-4"></div>

--- a/draw-client/src/Components/GameWindow/GameWindow.js
+++ b/draw-client/src/Components/GameWindow/GameWindow.js
@@ -4,29 +4,55 @@ import TeamGameArea from './TeamGameArea/TeamGameArea';
 import FailAlert from '../FailAlert/FailAlert';
 import ExitButton from '../ExitButton/ExitButton';
 import PauseButton from '../PauseButton/PauseButton';
+import DrawingCanvas from './DrawingCanvas/DrawingCanvas';
 
 const gameWindow = (props) => {
   
-    let timer = null;
-    if (props.game.time) {
-        timer = Math.round(parseInt(props.game.time.timeRemain));;
+    let canvas = null;
+    let prevWordLabel = null;
+
+    if (props.game.teams) {
+
+        const teamList = Object.keys(props.game.teams);
+        for (let i=0;i<teamList.length;i++) {
+            if (props.game.teams[teamList[i]].players[props.game.teams[teamList[i]].drawIndex] === props.user) {
+                if (props.game.teams[teamList[i]].isActive && props.game.state === 'active') {
+                    canvas = <DrawingCanvas team={teamList[i]} game={props.game} clearClicked={props.clearClicked} draw={props.draw} />
+                }
+            }
+        }
+        
+        if (props.game.state === "buffer" && props.game.prevWord !== "") {
+            prevWordLabel = <h3 className="text-center">Last Round: {props.game.prevWord}</h3>;
+        } else {
+            prevWordLabel = null;
+        }
     }
 
     return (
         <div className="container my-5 p-5 bg-light rounded border border-secondary shadow">
             <h3>Game Window</h3>
             <FailAlert status={props.status} message={props.message} />
-            <div className="row mt-5 text-center">
-                <ul className="text-center list-unstyled">
-                    <li>Timer: {timer}</li>
-                </ul>
-            </div>
+            <div className="row mt-5 mx-auto">
+                <div className="col-sm-4"></div>
+                <div className="col-sm-4">
+                    {canvas}
+                </div>
+                <div className="col-sm-4"></div>
+            </div>            
             <div className="row mt-5">
                 <PauseButton 
                     game={props.game}
                     pauseClicked={props.pauseClicked}
                     resumeClicked={props.resumeClicked}
                 />
+            </div>
+            <div className="row mt-5 container ">
+                <div className="col-sm-4"></div>
+                <div className="col-sm-4">
+                    {prevWordLabel}
+                </div>
+                <div className="col-sm-4"></div>                
             </div>
             <div className="row mt-5">
                 <div className="col-sm-1"></div>

--- a/draw-client/src/Components/GameWindow/TeamGameArea/DrawingCanvas/DrawingCanvas.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/DrawingCanvas/DrawingCanvas.js
@@ -2,7 +2,15 @@ import React from 'react';
 
 const drawingCanvas = (props) => {
 
-    if (props.game.teams) {        
+    let wordLabel = null;
+    if (props.game.teams) {   
+        if (props.game.state === 'active') {
+            wordLabel = <h3>Draw: {props.game.word}</h3>;
+        } else if (props.game.state === 'buffer' && props.game.prevWord !== "") {
+            wordLabel = <h3>Last Round: {props.game.prevWord}</h3>;
+        } else {
+            wordLabel = <h3>You are the Drawer!</h3>;
+        }
 
         const canvas = document.querySelector('#drawing-canvas canvas');
 
@@ -45,26 +53,28 @@ const drawingCanvas = (props) => {
             };
 
             const drawPoints = (ctx, points) => {
-                // draw a basic circle instead
-                if (points.length < 6) {
-                    let b = points[0];
+                if (props.game.state === 'active') {
+                    // draw a basic circle instead
+                    if (points.length < 6) {
+                        let b = points[0];
+                        ctx.beginPath();
+                        ctx.arc(b.x, b.y, ctx.lineWidth / 2, 0, Math.PI * 2, !0);
+                        ctx.closePath();
+                        ctx.fill();
+                        return
+                    }
                     ctx.beginPath();
-                    ctx.arc(b.x, b.y, ctx.lineWidth / 2, 0, Math.PI * 2, !0);
-                    ctx.closePath();
-                    ctx.fill();
-                    return
+                    ctx.moveTo(points[0].x, points[0].y);
+                    // draw a bunch of quadratics, using the average of two points as the control point
+                    let i = 1;
+                    for (i = 1; i < points.length - 2; i++) {
+                        let c = (points[i].x + points[i + 1].x) / 2,
+                            d = (points[i].y + points[i + 1].y) / 2;
+                        ctx.quadraticCurveTo(points[i].x, points[i].y, c, d)
+                    }
+                    ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
+                    ctx.stroke();
                 }
-                ctx.beginPath();
-                ctx.moveTo(points[0].x, points[0].y);
-                // draw a bunch of quadratics, using the average of two points as the control point
-                let i = 1;
-                for (i = 1; i < points.length - 2; i++) {
-                    let c = (points[i].x + points[i + 1].x) / 2,
-                        d = (points[i].y + points[i + 1].y) / 2;
-                    ctx.quadraticCurveTo(points[i].x, points[i].y, c, d)
-                }
-                ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
-                ctx.stroke();
             }
 
             const getMouse = (e, canvas) => {
@@ -93,7 +103,7 @@ const drawingCanvas = (props) => {
 
     return (
         <div id="drawing-canvas">
-            <h3>{props.game.word}</h3>
+            {wordLabel}
             <canvas display="block" width="300" height="300" className="bg-white rounded border border-secondary shadow"></canvas>
             <div>
                 <button 

--- a/draw-client/src/Components/GameWindow/TeamGameArea/TeamGameArea.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/TeamGameArea.js
@@ -14,8 +14,10 @@ const teamGameArea = (props) => {
 
         points = <p>Points: {props.game.teams[props.team].points}</p>
 
-        if (props.game.state === 'active') {
+        if (props.game.state === 'active' || props.game.prevState === 'active' ) {
             timer = <p>Timer: {Math.round(parseInt(props.game.time.timeRemain))}</p>
+        } else {
+            timer = <p>Next Round in: {Math.round(parseInt(props.game.time.timeRemain))}</p>
         }
 
         drawer = props.game.teams[props.team].players[props.game.teams[props.team].drawIndex];

--- a/draw-client/src/Components/GameWindow/TeamGameArea/TeamGameArea.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/TeamGameArea.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import DrawingCanvas from './DrawingCanvas/DrawingCanvas';
 import ViewingCanvas from './ViewingCanvas/ViewingCanvas';
 
 const teamGameArea = (props) => {
@@ -8,23 +7,27 @@ const teamGameArea = (props) => {
     let drawer = null;
     let active = null;
     let canvas = null;
-    let points = null
+    let points = null;
+    let timer = null;
 
     if (props.game.teams) {
+
+        points = <p>Points: {props.game.teams[props.team].points}</p>
+
+        if (props.game.state === 'active') {
+            timer = <p>Timer: {Math.round(parseInt(props.game.time.timeRemain))}</p>
+        }
+
         drawer = props.game.teams[props.team].players[props.game.teams[props.team].drawIndex];
         active = props.game.teams[props.team].isActive ? "Yes" : "No";
-        points = props.game.teams[props.team].points;
 
-        if ((active === "Yes") && (drawer === props.user)) {
-            canvas = <DrawingCanvas team={props.team} game={props.game} clearClicked={props.clearClicked} draw={props.draw} />
-        } else {
-            canvas = <ViewingCanvas id={props.team} user={props.user} game={props.game} guessClicked={props.guessClicked} />
-        }
+        canvas = <ViewingCanvas id={props.team} user={props.user} game={props.game} guessClicked={props.guessClicked} />
     }
     return (
         <div>
             <p>{props.team}</p>
-            <p>Points: {points}</p>
+            {points}
+            {timer}
             {canvas}
         </div>
     );

--- a/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
@@ -3,11 +3,8 @@ import React from 'react';
 const viewingCanvas = (props) => {
 
     let guessForm = null;
-    let timer = null; 
     
     if (props.game.teams) {
-
-        timer = Math.round(parseInt(props.game.time.timeRemain));
 
         const canvas = document.getElementById(props.id);
         if (canvas) {

--- a/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
@@ -3,6 +3,7 @@ import React from 'react';
 const viewingCanvas = (props) => {
 
     let guessForm = null; 
+    let prevWordLabel = null;
     if (props.game.teams) {
 
         const canvas = document.getElementById(props.id);
@@ -22,6 +23,11 @@ const viewingCanvas = (props) => {
         }
                    
         if (userOnTeam) {
+            if (props.game.state === "buffer" && props.game.prevWord !== "") {
+                prevWordLabel = <h3>Last Round: {props.game.prevWord}</h3>;
+            } else {
+                prevWordLabel = <h3>You are a Guesser!</h3>;
+            }
             if (props.game.teams[props.id].isActive) {
                 guessForm = <div>
                     <input id={"guess_"+props.id} placeholder="Guess" className="m-auto form-control" />
@@ -43,6 +49,7 @@ const viewingCanvas = (props) => {
 
     return (
         <div>
+            {prevWordLabel}
             <canvas width="300" height="300" id={props.id} className="bg-white rounded border border-secondary shadow"></canvas>
             {guessForm}
         </div>

--- a/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
+++ b/draw-client/src/Components/GameWindow/TeamGameArea/ViewingCanvas/ViewingCanvas.js
@@ -2,9 +2,12 @@ import React from 'react';
 
 const viewingCanvas = (props) => {
 
-    let guessForm = null; 
-    let prevWordLabel = null;
+    let guessForm = null;
+    let timer = null; 
+    
     if (props.game.teams) {
+
+        timer = Math.round(parseInt(props.game.time.timeRemain));
 
         const canvas = document.getElementById(props.id);
         if (canvas) {
@@ -23,12 +26,7 @@ const viewingCanvas = (props) => {
         }
                    
         if (userOnTeam) {
-            if (props.game.state === "buffer" && props.game.prevWord !== "") {
-                prevWordLabel = <h3>Last Round: {props.game.prevWord}</h3>;
-            } else {
-                prevWordLabel = <h3>You are a Guesser!</h3>;
-            }
-            if (props.game.teams[props.id].isActive) {
+            if (props.game.teams[props.id].isActive && props.game.state === 'active') {
                 guessForm = <div>
                     <input id={"guess_"+props.id} placeholder="Guess" className="m-auto form-control" />
                     <button 
@@ -49,7 +47,6 @@ const viewingCanvas = (props) => {
 
     return (
         <div>
-            {prevWordLabel}
             <canvas width="300" height="300" id={props.id} className="bg-white rounded border border-secondary shadow"></canvas>
             {guessForm}
         </div>

--- a/draw-client/src/Components/PauseButton/PauseButton.js
+++ b/draw-client/src/Components/PauseButton/PauseButton.js
@@ -3,19 +3,26 @@ import React from 'react';
 const pauseButton = (props) => {
     let label = null;
     let action = null;
+    let classes = null;
     if (props.game.state) {
         if (props.game.state==='paused') {
             label = 'Resume';
             action = props.resumeClicked;
-        } else {
+            classes = "btn btn-primary mx-1 my-2";
+        } else if (props.game.state==='buffer'){
+            label  = 'Round Over';
+            action = null;
+            classes = "btn btn-secondary mx-1 my-2";            
+        } else  if (props.game.state==='active'){
             label = 'Pause';
             action = props.pauseClicked;
+            classes = "btn btn-primary mx-1 my-2";
         }
     }
 
     return (
         <div className="mx-auto my-2">
-            <button type="button" className="btn btn-primary mx-1 my-2" onClick = {action}> {label} </button>        
+            <button type="button" className={classes} onClick = {action}> {label} </button>        
         </div>
     );
 };

--- a/draw-client/src/Components/PauseButton/PauseButton.js
+++ b/draw-client/src/Components/PauseButton/PauseButton.js
@@ -8,12 +8,8 @@ const pauseButton = (props) => {
         if (props.game.state==='paused') {
             label = 'Resume';
             action = props.resumeClicked;
-            classes = "btn btn-primary mx-1 my-2";
-        } else if (props.game.state==='buffer'){
-            label  = 'Round Over';
-            action = null;
-            classes = "btn btn-secondary mx-1 my-2";            
-        } else  if (props.game.state==='active'){
+            classes = "btn btn-primary mx-1 my-2";            
+        } else {
             label = 'Pause';
             action = props.pauseClicked;
             classes = "btn btn-primary mx-1 my-2";

--- a/draw-client/src/Containers/GameManager.js
+++ b/draw-client/src/Containers/GameManager.js
@@ -55,7 +55,8 @@ class GameManager extends Component {
         responseStatus : "",
         responseMessage: "",
         gameData : {},
-        prevTimeRemain : 0
+        prevTimeRemain : 0,
+        prevState : ""
     }
 
     componentDidMount() {
@@ -91,7 +92,11 @@ class GameManager extends Component {
                         this.clearViewingCanvas('team3');
                         this.clearViewingCanvas('team4');
                     }
-                    this.setState({ prevTimeRemain : gd['time']['timeRemain']})
+                    if (gd['state'] === "buffer" && this.state.prevState === "active") {
+                        this.pauseGameHandler();
+                    }
+                    this.setState({ prevTimeRemain : gd['time']['timeRemain']});
+                    this.setState({ prevState : gd['state']})
                 }
                 else {
                     this.setState({ username : "" });

--- a/draw-client/src/Containers/GameManager.js
+++ b/draw-client/src/Containers/GameManager.js
@@ -85,7 +85,7 @@ class GameManager extends Component {
                 if (response.data.status === "SUCCESS") {
                     let gd = response.data.data;
                     this.setState({ gameData : gd });
-                    if (gd['time']['timeRemain'] > this.state.prevTimeRemain) {
+                    if (gd['time']['timeRemain'] > this.state.prevTimeRemain && gd['state'] === 'active') {
                         this.clearViewingCanvas('team1');
                         this.clearViewingCanvas('team2');
                         this.clearViewingCanvas('team3');

--- a/server/draw-serve.py
+++ b/server/draw-serve.py
@@ -64,20 +64,25 @@ def guessedCorrectly(room,guessingTeam):
     game_collection.update_one({'name' : room}, {'$set' : {'teams' : gameData['teams']}})    
 
     #Get New Word
+    prevWord = gameData['word']
+    game_collection.update_one({'name' : room}, {'$set' : {'prevWord' : prevWord }})
     game_collection.update_one({'name' : room}, {'$set' : {'word' : getWord() }})
 
 def roundExpired(room):
 
     #Load game data
     gameData = game_collection.find_one({'name' : room})
-    
+
+    #Set state to Buffer    
+    game_collection.update_one({'name' : room}, {'$set' : {'state' : 'buffer'}})
+
     #Reset Idle Timer
     gameData['time']['idleSum'] = 0
     gameData['time']['idle'] = 0
 
-    #Reset Active Timer
-    gameData['time']['timeRemain'] = gameData['time']['drawLimit']
-    gameData['time']['active'] = time.time()
+    #Reset Buffer Timer
+    gameData['time']['timeRemain'] = gameData['time']['bufferLimit']
+    gameData['time']['buffer'] = time.time()
 
     #Upload New Timers to Server
     game_collection.update_one({'name' : room}, {'$set' : {'time' : gameData['time']}})
@@ -109,7 +114,31 @@ def roundExpired(room):
     game_collection.update_one({'name' : room}, {'$set' : {'teams' : gameData['teams']}})    
 
     #Get New Word
+    prevWord = gameData['word']
+    game_collection.update_one({'name' : room}, {'$set' : {'prevWord' : prevWord }})
     game_collection.update_one({'name' : room}, {'$set' : {'word' : getWord() }})
+
+def bufferExpired(room):
+
+    #Load game data
+    gameData = game_collection.find_one({'name' : room})
+
+    #Set state to Buffer    
+    game_collection.update_one({'name' : room}, {'$set' : {'state' : 'active'}})
+
+    #Reset Idle Timer
+    gameData['time']['idleSum'] = 0
+    gameData['time']['idle'] = 0
+
+    #Reset Buffer Timer
+    gameData['time']['buffer'] = 0
+
+    #Reset Active Timer
+    gameData['time']['timeRemain'] = gameData['time']['drawLimit']
+    gameData['time']['active'] = time.time()
+
+    #Upload New Timers to Server
+    game_collection.update_one({'name' : room}, {'$set' : {'time' : gameData['time']}})
 
 @app.route('/')
 def hello_world():
@@ -135,7 +164,16 @@ def gameData():
                 if (player == user):
                     isUserFound = True
 
-        if (isUserFound):            
+        if (isUserFound):
+
+            #Time Processing while in-between rounds
+            if gameData['state'] == 'buffer':
+                currTime = time.time()
+                gameData['time']['timeRemain'] = (gameData['time']['bufferLimit'] + gameData['time']['idleSum']) - (currTime - gameData['time']['buffer'])
+                game_collection.update_one({'name' : room}, {'$set' : {'time' : gameData['time']}})
+
+                if (gameData['time']['timeRemain'] < 0 ):
+                    bufferExpired(room)          
 
             #Time Processing while Active
             if gameData['state'] == 'active':
@@ -352,12 +390,12 @@ def startGame():
 
                     game_collection.update_one({'name' : room}, {'$set' : {'teams' : gameData['teams']}})
 
-                    #Set state to active
-                    game_collection.update_one({'name' : room}, {'$set' : {'state' : 'active'}})
+                    #Set state to buffer
+                    game_collection.update_one({'name' : room}, {'$set' : {'state' : 'buffer'}})
 
-                    #Start Active Timer
-                    gameData['time']['timeRemain'] = gameData['time']['drawLimit']
-                    gameData['time']['active'] = time.time()
+                    #Start Buffer Timer
+                    gameData['time']['timeRemain'] = gameData['time']['bufferLimit']
+                    gameData['time']['buffer'] = time.time()
                     game_collection.update_one({'name' : room}, {'$set' : {'time' : gameData['time']}})
 
                     response = flask.jsonify({ "status" : "SUCCESS", "message" : "Game Started" })
@@ -378,7 +416,6 @@ def pauseGame():
    
    #Get Request Parameters
     room = flask.request.form['room']
-    user = flask.request.form['user']
 
     #Check if Room Exists
     if (game_collection.count_documents({'name' : room}) > 0):
@@ -410,7 +447,6 @@ def resumeGame():
    
    #Get Request Parameters
     room = flask.request.form['room']
-    user = flask.request.form['user']
 
     #Check if Room Exists
     if (game_collection.count_documents({'name' : room}) > 0):
@@ -525,7 +561,6 @@ def guess():
 
                 #Verify user is on the team and not the drawer
                 isTeamMember = False
-                isTeamDrawer = False
                 for i,player in enumerate(gameData['teams'][team]['players']):
                     if (player == user):
                         isTeamMember = True

--- a/server/model.json
+++ b/server/model.json
@@ -5,10 +5,11 @@
     "code" : "",
     "word" : "",
     "prevWord": "",
+    "prevState":"",
     "turn" : -1,
     "time" : {
         "drawLimit" : 90,
-        "bufferLimit" : 10,
+        "bufferLimit" : 5,
         "timeRemain" : 0,
         "active" : 0,
         "buffer": 0,

--- a/server/model.json
+++ b/server/model.json
@@ -4,11 +4,14 @@
     "host" : "",
     "code" : "",
     "word" : "",
+    "prevWord": "",
     "turn" : -1,
     "time" : {
-        "drawLimit" : 60,
+        "drawLimit" : 120,
+        "bufferLimit" : 5,
         "timeRemain" : 0,
         "active" : 0,
+        "buffer": 0,
         "idle" : 0,
         "idleSum" : 0
     },

--- a/server/model.json
+++ b/server/model.json
@@ -7,8 +7,8 @@
     "prevWord": "",
     "turn" : -1,
     "time" : {
-        "drawLimit" : 120,
-        "bufferLimit" : 5,
+        "drawLimit" : 90,
+        "bufferLimit" : 10,
         "timeRemain" : 0,
         "active" : 0,
         "buffer": 0,


### PR DESCRIPTION
This branch includes a new game state, the _buffer_ state which runs for a set period of time (_bufferLimit_) in between each round. During this period, the previous word is shown alongside the final canvases from the previous round.

In order to implement this functionality as it was intended, a change to canvas rendering needed to be made. Four (4) viewing canvases are now always generated (one for each time), even for the drawer - instead of replacing the drawer's team viewing canvas with a drawing canvas, the drawer is given a fifth canvas for drawing. On the drawer's screen, their team's viewing canvas will live update as they draw. When the round ends, the drawing canvas is taken away, but the viewing canvases remain, along with a heading showing what the word was from the previous round.

Pause functionality was also changed. Pausing is no longer permitted during drawing (_active_ state). It is instead only allowed during the _buffer_ state. Based on the likeliness that teams will want as much time as they'd like to view the drawings from the previous round, the front-end application __automatically__ pauses the game upon every transition from _active_ to _buffer_ states. The game will stay in the _buffer_ state until someone manually resumes.

Closes #4 
