### PR TITLE
Updated DrawingCanvas to allow Touch Events

### DIFF
--- a/draw-client/src/Containers/GameManager.js
+++ b/draw-client/src/Containers/GameManager.js
@@ -7,33 +7,19 @@ import LobbyWindow from '../Components/LobbyWindow/LobbyWindow';
 import GameWindow from '../Components/GameWindow/GameWindow';
 
 let socket = io.connect('http://localhost:4000');
-const API_URL = "http://localhost:5000"
+const API_URL = "http://localhost:5000";
 
 //Listen Drawing Event
-socket.on('draw', (team,points) => {
+socket.on('draw', (team,initPos,finalPos) => {
     let canvas = document.getElementById(team);
-    if(canvas && points.length > 0) {
+    if(canvas) {
         const ctx = canvas.getContext('2d');
-
-        if (points.length < 6) {
-            let b = points[0];
+        if(initPos && finalPos) {
             ctx.beginPath();
-            ctx.arc(b.x, b.y, ctx.lineWidth / 2, 0, Math.PI * 2, !0);
-            ctx.closePath();
-            ctx.fill();
-            return
+            ctx.moveTo(initPos.x, initPos.y);
+            ctx.lineTo(finalPos.x, finalPos.y);
+            ctx.stroke();
         }
-        ctx.beginPath();
-        ctx.moveTo(points[0].x, points[0].y);
-        // draw a bunch of quadratics, using the average of two points as the control point
-        let i = 1;
-        for (i = 1; i < points.length - 2; i++) {
-            let c = (points[i].x + points[i + 1].x) / 2,
-                d = (points[i].y + points[i + 1].y) / 2;
-            ctx.quadraticCurveTo(points[i].x, points[i].y, c, d)
-        }
-        ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
-        ctx.stroke();
     }
 });
 
@@ -45,8 +31,6 @@ socket.on('clear', (team) => {
         ctx.clearRect(0, 0, canvas.width, canvas.height);      
     }
 });
-
-;
 
 class GameManager extends Component {
     state = {
@@ -193,10 +177,10 @@ class GameManager extends Component {
         })
     }
 
-    drawHandler = (team,points) => {
+    drawHandler = (team,initPos,finalPos) => {
         if (this.state.gameData.state === 'active') {
-        socket.emit('draw',team,points);        
-    }
+            socket.emit('draw',team,initPos,finalPos);        
+        }
     }
 
     clearViewingCanvas = (team) => {

--- a/sock-serve/index.js
+++ b/sock-serve/index.js
@@ -12,8 +12,8 @@ var io = socket(server);
 io.on('connection', (socket) => {
     console.log('Made socket connection: ' + socket.id);
 
-    socket.on('draw', (team,points) => {
-        io.sockets.emit('draw',team,points);
+    socket.on('draw', (team,initPos,finalPos) => {
+        io.sockets.emit('draw',team,initPos,finalPos);
     });
 
     socket.on('clear', (team) => {


### PR DESCRIPTION
Changed the entire drawing functionality within DrawingCanvas to mimic [this example](https://gist.github.com/bencentra/91350fe91c377c1ca574) which includes both mouse & touch events.

To reflect this change, had to modify the _emit_, _listen_, and _drawHandler_ functions within the WebSocket server / client code.

The fix itself seems to work, but Issue #10 becomes much more apparent due to testing on a mobile phone that isn't the localhost machine... The mobile user can draw pretty seamlessly, but when viewing/guessing, there is some significant lag that (in the worst cases) can make the game unplayable.

Closes #3 